### PR TITLE
Refactored the way data is fetched

### DIFF
--- a/src/containers/Home.js
+++ b/src/containers/Home.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import useData from '../hooks/useData'
 import { withStyles } from '@material-ui/core/styles'
 import Grid from '@material-ui/core/Grid'
 import Typography from '@material-ui/core/Typography'
@@ -37,10 +38,15 @@ const MapChartCard = createChartCard(MapChart)
 const Home = props => {
   const { classes } = props
 
+  const lineChartData = useData(lineChartURL)
+  const groupedBarChartData = useData(groupedBarChartURL)
+  const barChartData = useData(barChartURL)
+  const mapChartData = useData(mapURL)
+
   return (
     <div className={classes.root}>
       <Grid container spacing={16}>
-        <LineChartCard dataURL={lineChartURL} feedbackId={'lineChartId'} classes={classes} >
+        <LineChartCard data={lineChartData} feedbackId={'lineChartId'} classes={classes} >
           <Grid item container>
             <Grid item xs={12} container direction='column' spacing={8}>
               <Grid item>
@@ -49,8 +55,8 @@ const Home = props => {
             </Grid>
           </Grid>
         </LineChartCard>
-        <BarChartCard dataURL={barChartURL} feedbackId={'barChart'} classes={classes} />
-        <GroupedBarChartCard dataURL={groupedBarChartURL} feedbackId={'groupedBarChart'} classes={classes} />
+        <BarChartCard data={barChartData} feedbackId={'barChart'} classes={classes} />
+        <GroupedBarChartCard data={groupedBarChartData} feedbackId={'groupedBarChart'} classes={classes} />
         <TableCard tableHead={['ID', 'Name', 'Salary', 'Country']}
           tableData={[
             ['1', 'Dakota Rice', '$36,738', 'Niger'],
@@ -81,7 +87,7 @@ const Home = props => {
             </Grid>
           </Grid>
         </TableCard>
-        <MapChartCard dataURL={mapURL} classes={classes} xs={12} />
+        <MapChartCard data={mapChartData} classes={classes} xs={12} />
       </Grid>
     </div >
   )

--- a/src/containers/Instructor.js
+++ b/src/containers/Instructor.js
@@ -1,10 +1,10 @@
 import React from 'react'
+import useData from '../hooks/useData'
 import { withStyles } from '@material-ui/core/styles'
 import Grid from '@material-ui/core/Grid'
 import createChartCard from '../higherOrderComponents/createChartCard'
 import { lineChartURL } from '../data/gistURLs'
 import LineChart from '../components/LineChart'
-// import Typography from '@material-ui/core/Typography'
 
 const styles = theme => ({
   root: {
@@ -21,10 +21,12 @@ const LineChartCard = createChartCard(LineChart)
 const Instructor = props => {
   const { classes } = props
 
+  const lineChartData = useData(lineChartURL)
+
   return (
     <div className={classes.root}>
       <Grid container spacing={16}>
-        <LineChartCard dataURL={lineChartURL} classes={classes} />
+        <LineChartCard data={lineChartData} classes={classes} />
       </Grid>
     </div>
   )

--- a/src/containers/Student.js
+++ b/src/containers/Student.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import useData from '../hooks/useData'
 import { withStyles } from '@material-ui/core/styles'
 import Paper from '@material-ui/core/Paper'
 import Grid from '@material-ui/core/Grid'
@@ -34,45 +35,52 @@ const specialEmojis = [
 
 const Student = ({ classes }) => {
   const tip = createToolTip(d => `<p>${d.data}</p>`)
+
+  const groupedBarChartData = useData(groupedBarChartURL)
+  const sankeyData = useData(sankeyURL)
+  const barChartData = useData(barChartURL)
+  const lineChartData = useData(lineChartURL)
+  const histogramData = useData(histogramURL)
+
   return (
     <div className={classes.root}>
       <Grid container spacing={24}>
         <Grid item xs={12}>
           <Paper className={classes.paper}>
             <Typography>Grouped Bar Chart</Typography>
-            <GroupedBarChart dataURL={groupedBarChartURL} tip={tip} aspectRatio={0.5} />
+            <GroupedBarChart data={groupedBarChartData} tip={tip} aspectRatio={0.5} />
             <EmojiFeedback id='groupedBarChartFeedback' popoverText={'give feedback'} endpoints={emojiEndpoints} options={{ emojis: specialEmojis }} />
           </Paper>
         </Grid>
         <Grid item xs={12} sm={6}>
           <Paper className={classes.paper}>
             <Typography>Sankey Diagram</Typography>
-            <Sankey dataURL={sankeyURL} />
+            <Sankey data={sankeyData} />
             <EmojiFeedback id='sankeyFeedback' popoverText={'give feedback'} endpoints={emojiEndpoints} />
           </Paper>
         </Grid>
         <Grid item xs={12} sm={6}>
           <Paper className={classes.paper}>
             <Typography>Bar Chart</Typography>
-            <BarChart dataURL={barChartURL} tip={tip} />
+            <BarChart data={barChartData} tip={tip} />
           </Paper>
         </Grid>
         <Grid item xs={12} sm={6} md={4}>
           <Paper className={classes.paper}>
             <Typography>Histogram</Typography >
-            <Histogram dataURL={histogramURL} tip={createToolTip(d => `<p>${d.length}</p>`)} />
+            <Histogram data={histogramData} tip={createToolTip(d => `<p>${d.length}</p>`)} />
           </Paper>
         </Grid>
         <Grid item xs={12} sm={6} md={4}>
           <Paper className={classes.paper}>
             <Typography>Line Chart</Typography>
-            <LineChart dataURL={lineChartURL} />
+            <LineChart data={lineChartData} />
           </Paper>
         </Grid>
         <Grid item xs={12} sm={6} md={4}>
           <Paper className={classes.paper}>
             <Typography>Bar Chart</Typography>
-            <BarChart dataURL={barChartURL} tip={tip} />
+            <BarChart data={barChartData} tip={tip} />
           </Paper>
         </Grid>
       </Grid>

--- a/src/higherOrderComponents/createChartCard.js
+++ b/src/higherOrderComponents/createChartCard.js
@@ -7,7 +7,7 @@ const createChartCard = (ChartComponent, EmojiFeedback) => props => {
   const {
     classes,
     feedbackId,
-    dataURL,
+    data,
     xs = 12,
     sm = 6,
     md = 4
@@ -18,7 +18,7 @@ const createChartCard = (ChartComponent, EmojiFeedback) => props => {
       <Paper className={classes.paper}>
         {props.children}
         <Grid item xs={12}>
-          <ChartComponent dataURL={dataURL} />
+          <ChartComponent data={data} />
         </Grid>
         {EmojiFeedback !== undefined
           ? <EmojiFeedback id={feedbackId} popoverText={'give feedback'} endpoints={emojiEndpoints} />

--- a/src/higherOrderComponents/createChartComponent.js
+++ b/src/higherOrderComponents/createChartComponent.js
@@ -1,20 +1,13 @@
 import React, { useEffect, useState, memo } from 'react'
 import { destroyChart } from '../util/chartUtil'
-import getJSONFromGist from '../service/api'
 
 const createChartComponent = chart => memo(props => {
-  const { dataURL } = props
+  const { data } = props
   const [el, setEl] = useState(null)
-  const [chartData, setChartData] = useState(null)
 
   useEffect(() => {
-    getJSONFromGist(dataURL)
-      .then(data => setChartData(data))
-  }, [dataURL])
-
-  useEffect(() => {
-    if (el && chartData) {
-      chart({ ...props, el, data: chartData })
+    if (el && data) {
+      chart({ ...props, el, data })
       return () => destroyChart(el)
     }
   })

--- a/src/hooks/useData.js
+++ b/src/hooks/useData.js
@@ -1,0 +1,14 @@
+import { useState, useEffect } from 'react'
+import get from '../service/api'
+
+const useData = dataURL => {
+  const [data, setData] = useState(null)
+
+  useEffect(() => {
+    get(dataURL).then(data => setData(data))
+  }, [dataURL])
+
+  return data
+}
+
+export default useData

--- a/src/service/api.js
+++ b/src/service/api.js
@@ -1,9 +1,9 @@
 /* global fetch */
 
-const getJSONFromGist = url => {
+const get = url => {
   return fetch(url)
     .then(res => res.text())
     .then(data => JSON.parse(data))
 }
 
-export default getJSONFromGist
+export default get


### PR DESCRIPTION
I kept encountering a scenario in which I need the container to access the data, and since the data was being fetched in `createChartComponent`, there wasn't a way for the container to access this data.

I created a custom hook `useData` that can be called from within a container, and that way the container can use the data (to create components that add additional information to the charts). 

Now chart components do not take a `dataURL` prop, and instead takes `data` directly. 